### PR TITLE
Run missing env var check before audit

### DIFF
--- a/entrypoint.js
+++ b/entrypoint.js
@@ -7,7 +7,7 @@ const argv = tools.arguments;
 const { event, payload, sha } = tools.context;
 
 // check pre-requirements
-if (!checkForMissingEnv) tools.exit.failure("Failed!");
+if (!checkForMissingEnv()) tools.exit.failure("Failed!");
 
 // run the script
 runAudit();


### PR DESCRIPTION
Small fix to run the code instead of only checking if the function exists.